### PR TITLE
Feature/bd/image prune

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,50 +28,17 @@ RUN pip3 install --upgrade pip setuptools && \
     pip3 install --no-cache-dir \
         scipy \
         scikit-learn \
-        theano \
-        keras \
         torch \
         gym \
         jax \
         jaxlib \
         autograd \
-        tensorflow \
-        tensorboard \
-        tensorflow-estimator \
-        tensornetwork \
         cirq \
-        pennylane \
-        pennylane-qiskit \
-        pennylane-cirq \
-        pennylane-forest \
-        pennylane-qsharp \
         qiskit \
         pyquil \
-        tensorflow \
-        tensorflow-quantum \
         optuna \
         gpyopt \
         cvxopt
-
-# Install Rigetti QVM
-# TODO figure out nightly build installation
-WORKDIR /root
-RUN curl -O https://beta.quicklisp.org/quicklisp.lisp && \
-    echo '(quicklisp-quickstart:install)'  | sbcl --load quicklisp.lisp
-RUN git clone --recurse-submodules https://github.com/rigetti/quilc.git && \
-    cd quilc && \
-    git checkout v1.24.0 && \
-    make quilc && \
-    mv quilc /usr/local/bin
-RUN git clone https://github.com/rigetti/qvm.git && \
-    cd qvm && \
-    git fetch && \
-    git checkout v1.17.1 && \
-    make QVM_WORKSPACE=10240 qvm && \
-    mv qvm /usr/local/bin
-
-#TODO using legacy version to avoid pip install dependency hell
-RUN pip3 install pip==20.2.4
 
 WORKDIR /app
 ENTRYPOINT bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y --fix-missing && \
     update-alternatives --set python3 /usr/bin/python3.7 && \
     apt-get install -y curl git openssh-client && \
     apt-get install -y \
-        wget vim htop sbcl clang-7 gfortran\
+        wget vim htop sbcl clang-7 gfortran \
         libzmq3-dev libz-dev libblas-dev liblapack-dev && \
     apt-get clean
 
@@ -26,6 +26,7 @@ ENV PYTHONPATH="/usr/local/lib/python3.7/dist-packages:${PYTHONPATH}"
 # https://stackoverflow.com/questions/59800318/how-to-install-torch-in-python
 RUN pip3 install --upgrade pip setuptools && \
     pip3 install --no-cache-dir \
+        numpy \
         scipy \
         scikit-learn \
         torch \
@@ -35,7 +36,6 @@ RUN pip3 install --upgrade pip setuptools && \
         autograd \
         cirq \
         qiskit \
-        pyquil \
         optuna \
         gpyopt \
         cvxopt

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,20 +20,24 @@ RUN apt-get update -y --fix-missing && \
     apt-get clean
 
 ENV PYTHONPATH="/usr/local/lib/python3.7/dist-packages:${PYTHONPATH}"
+# PYTHONUNBUFFERED will dump python stdout to logs directly, rather than buffering
+# should resolve issue of not seeing python print statements in orquestra logs
+ENV PYTHONUNBUFFERED="1"
 
 # Install ML Libraries
 # pytorch installation will OOM fail without --no-cache-dir
 # https://stackoverflow.com/questions/59800318/how-to-install-torch-in-python
 RUN pip3 install --upgrade pip setuptools && \
     pip3 install --no-cache-dir \
+        dill \
         numpy \
         scipy \
         scikit-learn \
         torch \
-        gym \
         jax \
         jaxlib \
         autograd \
+        flax \
         cirq \
         qiskit \
         optuna \


### PR DESCRIPTION
The build for `z-qml:nightly` will retrigger after we merge this. We were originally leaning towards "ship everything", but we've been hitting dependency issues like "x requires z<=2.11, y requires z>2.13" that prevent the latest pip resolver from ever completing. We need to upgrade pip to allow for the support of setup.cfg, required by platform and QS teams, and I've been meaning to clean this up for a while.

So I think we should just ship the essentials on this image and allow for the python3-runtime on orquestra to install more dependencies as needed.

I'm debating adding version pins like we have in [orquestra-qml-core](https://github.com/zapatacomputing/orquestra-qml-core/blob/dev/setup.cfg#L19-L26), but this only runs and publishes a new image when something is merged into master. So it might work better to leave it unpinned. What do you think?